### PR TITLE
update "Requires: g++" to "gcc-c++" in rpm package spec

### DIFF
--- a/package/rpm/gim-dkms.spec
+++ b/package/rpm/gim-dkms.spec
@@ -31,7 +31,7 @@ License: MIT
 URL: https://github.com/amd/mxgpu-virtualization
 Source0: ./gim-%{full_version}.tar.gz
 BuildArch: noarch
-Requires: autoconf cmake dkms g++ kernel-devel
+Requires: autoconf cmake dkms gcc-c++ kernel-devel
 
 %description
 DKMS source for GIM driver.


### PR DESCRIPTION
As part of the PR https://github.com/ROCm/gpu-operator/pull/365, I'm trying to add "SLES support for AMD gpu-operator".

Part of the work requires adding a `internal/kmmmodule/dockerfiles/DockerfileTemplate.sles.gim` dockerfile template which will be installing the `gim-dkms` kernel module package in a container created with a SLES base image.

In SLES rpm package repos, the `gcc-c++` package installs the `g++` binary but it doesn't define `Provides: g++` rather it defines `Provides: gcc-c++`  which also matches with what is provided by the same  `gcc-c++` package in RHEL/CentOS repos as well.

This PR proposes updating the `gim-dkms` package rpm spec to require `gcc-c++` instead of the current `g++` for resolving the dependency on g++ binary, so that the `gim-dkms` installation works on SLES OS as well.

---

### Steps to verify/reproduce the "failed dependency" error w.r.t g++ on SLES OS:

- Dockerfile (only relevant part):
  
  
  ```Dockerfile
  FROM registry.suse.com/suse/sle15:15.6 AS builder

  RUN zypper --non-interactive addrepo \
      --no-gpgcheck \
      https://repo.radeon.com/amdgpu/6.2.2/sle/15.6/main/x86_64/ \
      amdgpu
  
  RUN zypper --non-interactive --gpg-auto-import-keys refresh
  
  RUN zypper --non-interactive install -y \
      kernel-default-devel \
      gcc-c++ \
      cmake \
      dkms \
      autoconf \
      automake
  
  RUN wget https://github.com/amd/MxGPU-Virtualization/releases/download/mainline%2F8.4.0.K/gim-dkms-8.4.0.K-0.noarch.rpm && \
      rpm -ivh gim-dkms-8.4.0.K-0.noarch.rpm && \
      rm gim-dkms-8.4.0.K-0.noarch.rpm
  ```

  results in error:
  
  ```
  2.392 error: Failed dependencies:
  2.392 	g++ is needed by gim-dkms-8.4.0.K-0.noarch
  ```
  ---
  
- while the `gcc-c++` package coming from the SLES base container indeed provides the `g++` binary:

  ```sh
  ❯ podman run -it --rm registry.suse.com/suse/sle15:15.6 /bin/bash
  b995e0b7bfa1:/ # zypper install gcc-c++
  
  
  b995e0b7bfa1:/ # zypper info --provides gcc-c++
  Refreshing service 'container-suseconnect-zypp'.
  Loading repository data...
  Reading installed packages...
  
  
  Information for package gcc-c++:
  --------------------------------
  Repository     : SLE_BCI
  Name           : gcc-c++
  Version        : 7-3.9.1
  Arch           : x86_64
  Vendor         : SUSE LLC <https://www.suse.com/>
  Support Level  : unsupported
  Installed Size : 0 B
  Installed      : Yes
  Status         : up-to-date
  Source package : gcc-7-3.9.1.src
  Upstream URL   : http://gcc.gnu.org/
  Summary        : The system GNU C++ Compiler
  Description    : 
      The system GNU C++ Compiler.
  Provides       : [3]
      c++_compiler
      gcc-c++ = 7-3.9.1
      gcc-c++(x86-64) = 7-3.9.1
  
  b995e0b7bfa1:/ # rpm -ql gcc-c++
  /usr/bin/c++
  /usr/bin/g++
  /usr/share/man/man1/c++.1.gz
  /usr/share/man/man1/g++.1.gz
  ``` 

- verified the same on RHEL ubi base image:
  
  ```sh
  ❯ podman run -it --rm docker.io/redhat/ubi8:8.10 /bin/bash 
  [root@d08ed1ae2ce1 /]# dnf install gcc-c++
  
  [root@d08ed1ae2ce1 /]# rpm -q --provides gcc-c++
  gcc-c++ = 8.5.0-28.el8_10
  gcc-c++(x86-64) = 8.5.0-28.el8_10
  
  [root@d08ed1ae2ce1 /]# rpm -ql gcc-c++
  /usr/bin/c++
  /usr/bin/g++
  ...
  ...
  ```