### PR TITLE
Resolve compilation failures on Debian 13

### DIFF
--- a/libgv/core/amdgv_oss_wrapper.h
+++ b/libgv/core/amdgv_oss_wrapper.h
@@ -23,11 +23,7 @@
 #ifndef AMDGV_OSS_WRAPPER_H
 #define AMDGV_OSS_WRAPPER_H
 
-#ifdef HAVE_LINUX_STDARG_H
 #include <linux/stdarg.h>
-#else
-#include <stdarg.h>
-#endif
 
 #include "amdgv.h"
 #include "amdgv_oss.h"

--- a/libgv/inc/amdgv_oss.h
+++ b/libgv/inc/amdgv_oss.h
@@ -23,11 +23,7 @@
 #ifndef AMDGV_OSS_H
 #define AMDGV_OSS_H
 
-#ifdef HAVE_LINUX_STDARG_H
 #include <linux/stdarg.h>
-#else
-#include <stdarg.h>
-#endif
 
 #include "amdgv_asic.h"
 


### PR DESCRIPTION
With reference to issue amd#11 "Debian DKMS issue because of separate linux common headers"

Make the code more debian-friendly implementing the change proposed there: include the kernel's own <linux/stdarg.h> instead of the system's <stdarg.h>.

With this the DKMS compilation and install have success on Debian 13.